### PR TITLE
Cins isimler

### DIFF
--- a/haller.js
+++ b/haller.js
@@ -16,7 +16,7 @@ var Hal = function(isim, hal) {
         iEkleri = 'ııiiuuüü',
         sonHarf = isim[isim.length - 1],
         istisna = ~~/[ei][^ıüoö]*[au]l$|alp$/.test(isim) * 2,   // Sapkali harf istisnasi var mı kontrol eder Orn: Alp, Resul, Cemal... 0 veya 2 degeri doner
-        sonSesli = isim.match(/[aıeiouöü]/g).pop(),   // seslilerden sonuncusunu alır
+        sonSesli = isim.toLowerCase().match(/[aıeiouöü]/g).pop(),   // seslilerden sonuncusunu alır
 
         // Ek in sesli harfine karar verir
         ek = (hal == iyelik || hal == iHali) ?  // iyelik veya i hali ise


### PR DESCRIPTION
Merhaba. Özel ve cins isimleri ayırtedebilme özelliği ekledim. Baş harfi büyük isimleri özel isim kabul edip hal eklerini kesme işareti ile ayıracak, küçük harf ile başlayan cins isimleri ise kesme işareti ile ayırmayacak. Bu şekilde daha mantıklı bir uygulama olacağını düşündüm.

Ayrıca dikkatimi çeken bir bug'ı da düzeltme imkanı buldum. Büyük sesli harfle başlayan isimlerde bir sıkıntı var (Örn: Ev, İş, Aşk, Us vs...), GitHub Pages'deki isim ve ekleri test ettiğimiz kısmında denedim orada da çalışmıyor. Basitçe girilen ismi ilgili satırda küçük harfe çevirince problem çözüldü.
